### PR TITLE
Update 10-11-2025

### DIFF
--- a/decorate/PickupGivers/PowerupGivers/ComputerMap2.dec
+++ b/decorate/PickupGivers/PowerupGivers/ComputerMap2.dec
@@ -1,7 +1,5 @@
 ACTOR ComputerMap2 : CustomInventory replaces Allmap
 {
-    Game Doom
-    SpawnID 132
     +COUNTITEM
     +INVENTORY.ALWAYSPICKUP
     Inventory.PickupSound "misc/getmap"

--- a/decorate/PickupGivers/PowerupGivers/Shield.dec
+++ b/decorate/PickupGivers/PowerupGivers/Shield.dec
@@ -1,7 +1,5 @@
 ACTOR Shield : CustomInventory replaces InvulnerabilitySphere
 {
-    Game Doom
-    SpawnID 132
     +COUNTITEM
     +INVENTORY.ALWAYSPICKUP
     Inventory.PickupMessage "$GOTINVUL"

--- a/decorate/PickupGivers/PowerupGivers/SuperCharge.dec
+++ b/decorate/PickupGivers/PowerupGivers/SuperCharge.dec
@@ -1,7 +1,5 @@
 ACTOR SuperCharge : CustomInventory replaces Soulsphere
 {
-    Game Doom
-    SpawnID 132
     +COUNTITEM
     +INVENTORY.ALWAYSPICKUP
     Inventory.PickupMessage "$GOTSUPER"

--- a/decorate/Pickups/PowerupPickups/Allmap_TO.dec
+++ b/decorate/Pickups/PowerupPickups/Allmap_TO.dec
@@ -1,8 +1,5 @@
 ACTOR Allmap_TO : MapRevealer
 {
-    Game Doom
-    SpawnID 137
-    +COUNTITEM
     +INVENTORY.FANCYPICKUPSOUND
     +INVENTORY.ALWAYSPICKUP
     Inventory.MaxAmount 0

--- a/decorate/Pickups/PowerupPickups/Berserk_TO.dec
+++ b/decorate/Pickups/PowerupPickups/Berserk_TO.dec
@@ -1,7 +1,5 @@
 ACTOR Berserk_TO : CustomInventory replaces Berserk
 {
-    Game Doom
-    SpawnID 134
     +COUNTITEM
     +INVENTORY.ALWAYSPICKUP
     Inventory.PickupMessage "$GOTBERSERK"

--- a/decorate/Pickups/PowerupPickups/BlurSphere_TO.dec
+++ b/decorate/Pickups/PowerupPickups/BlurSphere_TO.dec
@@ -1,8 +1,5 @@
 ACTOR BlurSphere_TO : PowerupGiver
 {
-    Game Doom
-    SpawnID 135
-    +COUNTITEM
     +VISIBILITYPULSE
     +INVENTORY.AUTOACTIVATE
     +INVENTORY.ALWAYSPICKUP

--- a/decorate/Pickups/PowerupPickups/Infrared_TO.dec
+++ b/decorate/Pickups/PowerupPickups/Infrared_TO.dec
@@ -1,8 +1,5 @@
 ACTOR Infrared_TO : PowerupGiver
 {
-    Game Doom
-    SpawnID 138
-    +COUNTITEM
     +INVENTORY.AUTOACTIVATE
     +INVENTORY.ALWAYSPICKUP
     Inventory.MaxAmount 0

--- a/decorate/Pickups/PowerupPickups/InvulnerabilitySphere_TO.dec
+++ b/decorate/Pickups/PowerupPickups/InvulnerabilitySphere_TO.dec
@@ -1,8 +1,5 @@
 ACTOR InvulnerabilitySphere_TO : PowerupGiver
 {
-    Game Doom
-    SpawnID 133
-    +COUNTITEM
     +INVENTORY.AUTOACTIVATE
     +INVENTORY.ALWAYSPICKUP
     +INVENTORY.BIGPOWERUP

--- a/decorate/Pickups/PowerupPickups/Megasphere_TO.dec
+++ b/decorate/Pickups/PowerupPickups/Megasphere_TO.dec
@@ -1,7 +1,5 @@
 ACTOR Megasphere_TO : CustomInventory replaces Megasphere
 {
-    Game Doom
-    SpawnID 132
     +COUNTITEM
     +INVENTORY.ALWAYSPICKUP
     Inventory.PickupMessage "$GOTMSPHERE"

--- a/decorate/Pickups/PowerupPickups/RadSuit_TO.dec
+++ b/decorate/Pickups/PowerupPickups/RadSuit_TO.dec
@@ -1,7 +1,5 @@
 ACTOR RadSuit_TO : PowerupGiver
 {
-    Game Doom
-    SpawnID 136
     Height 46
     +INVENTORY.AUTOACTIVATE
     +INVENTORY.ALWAYSPICKUP

--- a/decorate/Pickups/PowerupPickups/Soulsphere_TO.dec
+++ b/decorate/Pickups/PowerupPickups/Soulsphere_TO.dec
@@ -1,9 +1,5 @@
-//For manipulation in DeHackEd
 ACTOR Soulsphere_TO : Health
 {
-    Game Doom
-    SpawnID 25
-    +COUNTITEM
     +INVENTORY.AUTOACTIVATE
     +INVENTORY.ALWAYSPICKUP
     +INVENTORY.FANCYPICKUPSOUND


### PR DESCRIPTION
Fixed the Toby Doom Powerups. Removed or altered the Spawn IDs since they were conflicting with the their original counterparts in the tutorial levels.